### PR TITLE
option to build from puppet modules files or locally stored file

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,0 +1,12 @@
+name    'puppet-module-build'
+version '1.0.0'
+source 'git://github.com/jfqd/puppet-module-build.git'
+author 'qutic development'
+license 'MIT'
+summary 'Puppet module for building tools or libraries from source if no distribution package is available.'
+description 'Puppet module for building tools or libraries from source if no distribution package is available.'
+project_page 'https://github.com/jfqd/puppet-module-build'
+
+## Add dependencies, if any:
+# dependency 'DavidSchmitt-common', '1.x'
+# dependency 'puppetlabs-stdlib', '>= 3.0.0'

--- a/Readme.textile
+++ b/Readme.textile
@@ -1,32 +1,60 @@
 h1. Puppet build module
 
-"Puppet":http://projects.reductivelabs.com module for building tools or libraries from source if no distribution package is available.
+"Puppet":http://puppetlabs.com module for building tools or libraries from source if no distribution package is available.
 
-h2. Usage
+h2. Usage (downloading source from internet)
 
 <pre>
 build::install { 'top':
-  download => 'http://www.unixtop.org/dist/top-3.7.tar.gz',
+  file     => 'http://www.unixtop.org/dist/top-3.7.tar.gz',
   creates  => '/usr/local/bin/top',
 }
 </pre>
 
 This function will download the source of the top command, extract it and run a ./configure, make, make install for you.
 
+h2. Usage (using locally stored or puppet module files as source for building)
+
+<pre>
+build::install { 'top':
+  file     => 'puppet:///modules/your-module/top-3.7.tar.gz',
+  creates  => '/usr/local/bin/top',
+}
+</pre>
+
+File could be stored even in puppet module files.
+
+<pre>
+build::install { 'tomcat-apr':
+  file            => '/opt/apache-tomcat/bin/tomcat-native.tar.gz',
+  creates         => '/usr/local/apr/lib/libtcnative-1.so',
+  buildoptions    => '--with-apr=`which apr-1-config` --with-java-home=\'/usr/lib/jvm/java-7-oracle\' --with-ssl=yes',
+  extract_options => '--transform=\'s,tomcat-native-.*-src,tomcat-native,\'',
+  pkg_folder      => 'tomcat-native/jni/native',
+}
+</pre>
+
+This example will install Tomcat APR native library from source bundled with Tomcat package. 
+p.s. paths are Ubuntu specific
+
+
 h2. Optional parameters
 
 | pkg_folder      | Name of the extracted package folder    |
 | pkg_format      | Pkg-Format                              |
 | pkg_extension   | Pkg-Extension                           |
-| extractorcmd    | Overwrite pre defined extract commands  |
+| extractor_cmd   | Overwrite pre defined extract commands  |
+| extract_options | Additional options to extractor tool    |
 | make_cmd        | Overwrite pre defined make commands     |
-| buildoptions    | Additional build options for configure  |
+| build_options   | Additional build options for configure  |
 | rm_build_folder | Remove the build folder (true, false)   |
+| src_cwd         | Folder where source is extracted and built. Defaults to '/usr/local/src' |
 
 h2. Dependencies
 
-"Puppet":http://projects.reductivelabs.com
+"Puppet":http://puppetlabs.com/puppet/puppet-open-source
 "puppet-common":https://github.com/puppet-modules/puppet-common
+"puppet-stdlib":https://github.com/puppetlabs/puppetlabs-stdlib
 
 h2. Note
 

--- a/Readme.textile
+++ b/Readme.textile
@@ -13,7 +13,7 @@ build::install { 'top':
 
 This function will download the source of the top command, extract it and run a ./configure, make, make install for you.
 
-h2. Usage (using locally stored or puppet module files as source for building)
+h2. Usage (locally stored or puppet module files)
 
 <pre>
 build::install { 'top':
@@ -22,20 +22,20 @@ build::install { 'top':
 }
 </pre>
 
-File could be stored even in puppet module files.
+This example will install top command, source code is stored within puppet module files.
 
 <pre>
 build::install { 'tomcat-apr':
   file            => '/opt/apache-tomcat/bin/tomcat-native.tar.gz',
   creates         => '/usr/local/apr/lib/libtcnative-1.so',
-  buildoptions    => '--with-apr=`which apr-1-config` --with-java-home=\'/usr/lib/jvm/java-7-oracle\' --with-ssl=yes',
+  build_options    => '--with-apr=`which apr-1-config` --with-java-home=\'/usr/lib/jvm/java-7-oracle\' --with-ssl=yes',
   extract_options => '--transform=\'s,tomcat-native-.*-src,tomcat-native,\'',
   pkg_folder      => 'tomcat-native/jni/native',
 }
 </pre>
 
 This example will install Tomcat APR native library from source bundled with Tomcat package. 
-p.s. paths are Ubuntu specific
+p.s. this example paths are Ubuntu specific
 
 
 h2. Optional parameters

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,106 +1,108 @@
 # Debian/nexenta specific build module
 #
 # build::install { 'top':
-#   download => 'http://www.unixtop.org/dist/top-3.7.tar.gz',
+#   file => 'http://www.unixtop.org/dist/top-3.7.tar.gz',
 #   creates  => '/usr/local/bin/top',
 # }
 
 define build::install (
-  $download,
+  $file,
   $creates,
-  $pkg_folder='',
-  $pkg_format="tar",
-  $pkg_extension="",
-  $buildoptions="",
-  $extractorcmd="",
-  $make_cmd="",
-  $rm_build_folder=true) {
-  
-  build::requires { "$name-requires-build-essential":  package => 'build-essential' }
-  
+  $pkg_folder         = '',
+  $pkg_format         = 'tar',
+  $pkg_extension      = '',
+  $build_options      = '',
+  $extractor_cmd      = '',
+  $extract_options    = '',
+  $make_cmd           = '',
+  $src_cwd            = '/usr/local/src',
+  $rm_build_folder    = true
+  ) {
+
+  if $file == undef {
+    fail('parameter $file not set')
+  }
+
+  $filename = basename($file)
+  $extratable_file = "${src_cwd}/${filename}"
+
   Exec {
-    unless => "$test -f $creates",
+    unless => "test -f ${creates}",
+    path => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/" ]
   }
   
-  $cwd    = "/usr/local/src"
-  
-  $test   = "/usr/bin/test"
-  $unzip  = "/usr/bin/unzip"
-  $tar    = "/usr/sbin/tar"
-  $bunzip = "/usr/bin/bunzip2"
-  $gunzip = "/usr/bin/gunzip"
-  
-  $filename = basename($download)
-  
   $extension = $pkg_format ? {
-    zip     => ".zip",
-    bzip    => ".tar.bz2",
-    tar     => ".tar.gz",
-    default => $pkg_extension,
+    'zip'     => ".zip",
+    'bzip'    => ".tar.bz2",
+    'tar'     => ".tar.gz",
+    default   => $pkg_extension,
   }
   
   $foldername = $pkg_folder ? {
     ''      => gsub($filename, $extension, ""),
     default => $pkg_folder,
   }
-  
-  $extractor = $pkg_format ? {
-    zip     => "$unzip -q -d $cwd $cwd/$filename",
-    bzip    => "$bunzip -c $cwd/$filename | $tar -xf -",
-    tar     => "$gunzip < $cwd/$filename | $tar -xf -",
-    default => $extractorcmd,
+
+  ensure_resource('package', 'build-essential', {'ensure' => 'present' })
+  ensure_resource('package', 'wget', {'ensure' => 'present' })
+
+  if $file =~ /^http/ {
+    notice("downloading ${file}")
+    exec { "download-${name}":
+      cwd     => $src_cwd,
+      command => "wget -q ${file}",
+      timeout => 120, # 2 minutes
+      before  => Exec["extract-${name}"],
+    }
+  } else {
+    notice("copying local file ${file}")
+    file { "${extratable_file}":
+      ensure  => present,
+      source  => $file,
+      before  => Exec["extract-${name}"],
+    }
   }
 
+  $extractor = $pkg_format ? {
+    'zip'     => "unzip -q ${extract_options} -d ${src_cwd} ${extratable_file}",
+    'bzip'    => "bunzip2 -c ${extratable_file} | tar ${extract_options} -xf -",
+    'tar'     => "gunzip < ${extratable_file} | tar ${extract_options} -xf -",
+    default   => $extractor_cmd,
+  }
+
+  exec { "extract-${name}":
+    cwd     => $src_cwd,
+    command => $extractor,
+    timeout => 120, # 2 minutes,
+  }
+
+  exec { "config-${name}":
+    cwd     => "${src_cwd}/${foldername}",
+    command => "${src_cwd}/${foldername}/configure ${buildoptions}",
+    timeout => 120, # 2 minutes
+    require => Exec["extract-${name}"],
+  }
+  
   $make = $make_cmd ? {
-    '' => '/usr/bin/make && /usr/bin/make install',
+    ''      => 'make && make install',
+    verbose => true,
     default => $make_cmd,
   }
-  
-  exec { "download-$name":
-    cwd     => "$cwd",
-    command => "/usr/bin/wget -q $download",
-    timeout => 120, # 2 minutes
-  }
-  
-  exec { "extract-$name":
-    cwd     => "$cwd",
-    command => "$extractor",
-    timeout => 120, # 2 minutes
-    require => Exec["download-$name"],
-  }
-  
-  exec { "config-$name":
-    cwd     => "$cwd/$foldername",
-    command => "$cwd/$foldername/configure $buildoptions",
-    timeout => 120, # 2 minutes
-    require => Exec["extract-$name"],
-  }
-  
-  exec { "make-install-$name":
-    cwd     => "$cwd/$foldername",
-    command => "$make",
-    timeout => 600, # 10 minutes
-    require => Exec["config-$name"],
-  }
-  
-  # remove build folder
-  case $rm_build_folder {
-    true: {
-      notice("remove build folder")
-      exec { "remove-$name-build-folder":
-        cwd     => "$cwd",
-        command => "/usr/bin/rm -rf $cwd/$foldername",
-        require => Exec["make-install-$name"],
-      } # exec
-    } # true
-  } # case
-  
-}
 
-define build::requires ( $ensure='installed', $package ) {
-  if defined( Package[$package] ) {
-    debug("$package already installed")
-  } else {
-    package { $package: ensure => $ensure }
+  exec { "make-install-${name}":
+    cwd     => "${src_cwd}/${foldername}",
+    command => $make,
+    timeout => 600, # 10 minutes
+    require => Exec["config-${name}"],
+  }
+  
+  if str2bool($rm_build_folder) {
+    notice('remove build folder')
+
+    exec { "remove-${name}-build-folder":
+      cwd     => $src_cwd,
+      command => "rm -rf ${src_cwd}/${foldername}",
+      require => Exec["make-install-${name}"],
+    }
   }
 }


### PR DESCRIPTION
I have modified build module code to support building source code stored within puppet module files or even locally.  I'm using your modified module to provision tomcat application servers with native APR library. Tomcat bundles apr source with tomcat release tar. Also I've added Modulefile as it helps resolving module dependencies. 

This change is tested on Ubuntu 13.04 / Puppet 3.2.4
